### PR TITLE
wrapped $::selinux in str2bool because is needs to be converted from a s...

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -47,7 +47,7 @@ class samba::server (
   }
 
   # SELinux options
-  if $::selinux {
+  if (str2bool($::selinux)) {
     Selboolean { persistent => true }
     if $selinux_enable_home_dirs {
       selboolean { 'samba_enable_home_dirs': value => 'on' }


### PR DESCRIPTION
I've wrapped $::selinux in str2bool because is needs to be converted from a string to a boolean to be evaluated properly

http://docs.puppetlabs.com/puppet/3/reference/lang_datatypes.html#automatic-conversion-to-boolean

Empty strings are false; all other strings are true. That means the string "false" actually resolves as true. Warning: all facts are strings in this version of Puppet, so “boolean” facts must be handled carefully.

if ($::selinux)

will always return true, whereas

if (str2bool($::selinux)) 

will return the actual value
