### PR TITLE
Add  guest_account to parameters, maps to 'guest account'

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,6 +23,7 @@ class samba::server (
   $local_master             = undef,
   $security                 = 'user',
   $map_to_guest             = undef,
+  $guest_account            = undef,
   $os_level                 = undef,
   $preferred_master         = undef,
   $extra_global_options     = [],

--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -25,6 +25,9 @@
 <% if @map_to_guest -%>
 	map to guest = <%= @map_to_guest %>
 <% end -%>
+<% if @guest_account -%>
+	guest account = <%= @guest_account %>
+<% end -%>
 <% if @passdb_backend == 'ldapsam' -%>
 	passdb backend = ldapsam:"<%= @ldap_url %>"
 	ldap ssl = <%= @ldap_ssl %>


### PR DESCRIPTION
Thanks for the Samba module, really helpful to me as a lot of Developers don't consider Windows hosts machines when working with Vagrant.

I find it useful to be able to use Samba 'guest account' to change the guest user, particularly when using Puppet to provision a guest machine with Vagrant. The default guest user 'nobody' can cause problems with permissions. I have added $guest_account parameter. 
