### PR TITLE
samba::params - Debian 8 (jessie) uses different service names

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,11 @@ class samba::params {
       if $::operatingsystem == 'Ubuntu' {
         $service = [ 'smbd' ]
       } else {
-        $service = [ 'samba' ]
+        if $::operatingsystemmajrelease <= 7 {
+          $service = [ 'samba' ]
+        } else {
+          $service = [ 'smbd', 'nmbd' ]
+        }
       }
       $secretstdb = '/var/lib/samba/secrets.tdb'
       $config_file = '/etc/samba/smb.conf'


### PR DESCRIPTION
You need to use =smbd= and =nmbd= services now on Debian instead of just =samba=.