### PR TITLE
Fix secrets.tdb for ubuntu trusty

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,10 +16,14 @@ class samba::params {
     'Debian': {
       if $::operatingsystem == 'Ubuntu' {
         $service = [ 'smbd' ]
+        if versioncmp($::lsbdistrelease, '14.04') >= 0 {
+          $secretstdb = '/var/lib/samba/private/secrets.tdb'
+        } else {
+          $secretstdb = '/var/lib/samba/secrets.tdb'
+        }
       } else {
         $service = [ 'samba' ]
       }
-      $secretstdb = '/var/lib/samba/secrets.tdb'
       $config_file = '/etc/samba/smb.conf'
       $package = 'samba'
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -59,7 +59,8 @@ class samba::server (
   if $ldap_admin_dn_pwd {
     package { 'tdb-tools' : ensure => installed }
 
-    exec { "/usr/bin/smbpasswd -w \"${ldap_admin_dn_pwd}\"":
+    exec { 'samba::server smbpasswd':
+      command => "/usr/bin/smbpasswd -w \"${ldap_admin_dn_pwd}\"",
       unless  => "/usr/bin/tdbdump ${::samba::params::secretstdb} | /bin/grep -e '^data([0-9]\\+) = \"${ldap_admin_dn_pwd}\\\\00\"$'",
       require => [
         File[$::samba::params::config_file],


### PR DESCRIPTION
The path of secrets.tdb has changed in ubuntu 14.04 trusty. This patch fixes the path for this scenario