### PR TITLE
Debian changed service from 'samba' to 'smbd'.  Closes GH-17

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,11 @@ class samba::params {
       if $::operatingsystem == 'Ubuntu' {
         $service = [ 'smbd' ]
       } else {
-        $service = [ 'samba' ]
+        if ($::operatingsystem == 'Debian') and ($::operatingsystemmajrelease >= '8') {
+          $service = [ 'smbd' ]
+        } else {
+          $service = [ 'samba' ]
+        } 
       }
       $secretstdb = '/var/lib/samba/secrets.tdb'
       $config_file = '/etc/samba/smb.conf'


### PR DESCRIPTION
Debian 8 changed the name of the Samba service from 'samba' to 'smbd'.